### PR TITLE
Added Support for Build Tools 20

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ The `wercker/android` box runs on ubuntu 12.04 and provides a selection of the A
 
 * gradle 1.12
 * android sdk version 23
-* android build tools 18.0.1, 19.0.3 and 19.1
+* android build tools 18.0.1, 19.0.3 and 19.1, 20.0
 * android API 18 (android 4.3) and 19 (android 4.4)
 * sys image 19 (emulators)
 * android support library

--- a/install-sdk.sh
+++ b/install-sdk.sh
@@ -12,6 +12,9 @@ export PATH="${PATH}:${ANDROID_HOME}/tools:${ANDROID_HOME}/platform-tools"
 
 type android || { echo "Path: $PATH"; echo 'Android not availble after installation, terminating.'; exit 1; }
 
+export ANDROID_BUILD_TOOLS="20.0"
+export ANDROID_VERSION="4.4.2"
+source $WERCKER_SOURCE_DIR/install-build-tools.sh
 export ANDROID_BUILD_TOOLS="19.1"
 export ANDROID_VERSION="4.4.2"
 source $WERCKER_SOURCE_DIR/install-build-tools.sh
@@ -25,7 +28,7 @@ source $WERCKER_SOURCE_DIR/install-build-tools.sh
 # export ANDROID_VERSION="4.2.2"
 # source $WERCKER_SOURCE_DIR/install-build-tools.sh
 
-export ANDROID_BUILD_TOOLS="18.0.1,19.0.3,19.1"
+export ANDROID_BUILD_TOOLS="18.0.1,19.0.3,19.1,20.0"
 
 
 # Write environment variables setup to $profile

--- a/install-sdk.sh
+++ b/install-sdk.sh
@@ -12,7 +12,7 @@ export PATH="${PATH}:${ANDROID_HOME}/tools:${ANDROID_HOME}/platform-tools"
 
 type android || { echo "Path: $PATH"; echo 'Android not availble after installation, terminating.'; exit 1; }
 
-export ANDROID_BUILD_TOOLS="20.0"
+export ANDROID_BUILD_TOOLS="20"
 export ANDROID_VERSION="4.4.2"
 source $WERCKER_SOURCE_DIR/install-build-tools.sh
 export ANDROID_BUILD_TOOLS="19.1"
@@ -28,7 +28,7 @@ source $WERCKER_SOURCE_DIR/install-build-tools.sh
 # export ANDROID_VERSION="4.2.2"
 # source $WERCKER_SOURCE_DIR/install-build-tools.sh
 
-export ANDROID_BUILD_TOOLS="18.0.1,19.0.3,19.1,20.0"
+export ANDROID_BUILD_TOOLS="18.0.1,19.0.3,19.1,20"
 
 
 # Write environment variables setup to $profile

--- a/install-sdk.sh
+++ b/install-sdk.sh
@@ -13,7 +13,7 @@ export PATH="${PATH}:${ANDROID_HOME}/tools:${ANDROID_HOME}/platform-tools"
 type android || { echo "Path: $PATH"; echo 'Android not availble after installation, terminating.'; exit 1; }
 
 export ANDROID_BUILD_TOOLS="20"
-export ANDROID_VERSION="4.4.2"
+export ANDROID_VERSION="4.4W"
 source $WERCKER_SOURCE_DIR/install-build-tools.sh
 export ANDROID_BUILD_TOOLS="19.1"
 export ANDROID_VERSION="4.4.2"


### PR DESCRIPTION
Some users might want to use the recent version of the android build tools. We updated the box setup to include the installation of the build tools 20.