### PR TITLE
Add Android SDK filter for api revel 20 and 21

### DIFF
--- a/filter.list
+++ b/filter.list
@@ -1,4 +1,6 @@
 platform-tools
+android-21
+android-20
 android-19
 android-18
 sys-img-armeabi-v7a-android-19


### PR DESCRIPTION
@flenter 
Currently my app is failed to build on wercker service, I have added Android SDK filter for api revel 20 and 21.
Then I have sent this PR.

BRs
@cafedeaqua